### PR TITLE
Updated busybox & removed hard-coded loop device

### DIFF
--- a/bin/build-galeforce.sh
+++ b/bin/build-galeforce.sh
@@ -3,14 +3,15 @@
 pushd $(dirname "$0")
 source ./common.sh
 
-BUSYBOX_URL="https://busybox.net/downloads/binaries/1.26.2-defconfig-multiarch/busybox-armv6l"
-DROPBEAR_URL="http://archive.raspbian.org/raspbian/pool/main/d/dropbear/dropbear-bin_2017.75-1_armhf.deb"
+BUSYBOX_URL="https://busybox.net/downloads/binaries/1.28.1-defconfig-multiarch/busybox-armv8l"
+DROPBEAR_URL="http://archive.raspbian.org/raspbian/pool/main/d/dropbear/dropbear-bin_2018.76-4_armhf.deb"
 
 function downloadBusybox() {
   if [ ! -f "$DOWNLOADS_DIR/busybox" ]
   then
     echo "Downloading busybox"
     curl -s $BUSYBOX_URL -o $DOWNLOADS_DIR/busybox
+    chmod +x $DOWNLOADS_DIR/busybox
   fi
 }
 

--- a/bin/build-image.sh
+++ b/bin/build-image.sh
@@ -17,6 +17,7 @@ DEV_KEYS_URL="https://chromium.googlesource.com/chromiumos/platform/vboot_refere
 DEV_KEYS_DIR="$DOWNLOADS_DIR/devkeys"
 MOUNTS_DIR="$BUILD_DIR/mounts"
 mkdir -p "$DEV_KEYS_DIR" "$MOUNTS_DIR"
+LOOP_MOUNT_NUMBER=18
 
 function getImageMetadata() {
   curl -s $IMAGE_METADATA_URL | jq '.[] | select(.hwidmatch | test(".*'"$BOARD"'.*";"i"))| {name, sha1, url}'
@@ -96,7 +97,8 @@ function getLoopDeviceForPartition() {
 
   img=$BUILD_DIR/$BOARD.bin
   partitionNumber=$(parted $img unit B print | grep $partitionName | tr -s ' ' | cut -d ' ' -f2)
-  echo "/dev/mapper/loop0p$partitionNumber"
+  loopDevice=$(printf "%sp%s" $LOOP_MOUNT_NUMBER $partitionNumber)
+  echo "/dev/mapper/loop$loopDevice"
 }
 
 function enableReadWrite() {
@@ -137,10 +139,10 @@ function patchRoot() {
   echo '/galeforce/bin/recovery.sh "${INSTALL_ROOT}"' >> usr/sbin/chromeos-postinst
   cat usr/sbin/chromeos-postinst
   # Debug - add telnet
-#  sudo cp galeforce/conf/telnet.conf etc/init
-#  sudo cp galeforce/conf/shadow etc/shadow
-#  sudo cp galeforce/bin/busybox bin
-#  sudo chmod u+x bin/busybox
+  sudo cp galeforce/conf/telnet.conf etc/init
+  sudo cp galeforce/data/shadow etc/shadow
+  sudo cp galeforce/bin/busybox bin
+  sudo chmod u+x bin/busybox
 
   popd
   unmountPartition $rootName
@@ -205,9 +207,12 @@ function createPatchImage() {
   cp "$DOWNLOADS_DIR/$BOARD.bin" "$BUILD_DIR/$BOARD.bin"
 
   echo "Mapping partitions to loop devices"
-  sudo kpartx -a "$BUILD_DIR/$BOARD.bin"
+  LOOP_MOUNT_NUMBER=$(sudo kpartx -v -a "$BUILD_DIR/$BOARD.bin" | head -n 1 | awk '{print $3}' | cut -d'p' -f 2)
+
   # Need to wait a little bit for them to be ready
   sleep 2
+
+  echo "About to patch ROOT-A"
 
   # This is the main root (there's also ROOT-B)
   patchRoot ROOT-A


### PR DESCRIPTION
Now the loopdevice is generic and is found from kpartx. So now,
the code is building properly as expected.